### PR TITLE
Fixes circular component sizing functionality for all devices. Fix #9

### DIFF
--- a/src/components/circular.js
+++ b/src/components/circular.js
@@ -5,14 +5,16 @@ import styled from "styled-components"
 const SemiCircle = styled.div`
   position: absolute;
   width: 100vh;
-  height: 110vh;
   z-index:-1;
-  top: -5vh;
   /* prettier stop */
   ${props => {
-    return props.left
-      ? `border-top-right-radius: 100%; border-bottom-right-radius: 100%; right:0`
-      : `border-top-left-radius: 100%; border-bottom-left-radius: 100%; left:0`
+    if (props.left) {
+      return `border-top-right-radius: 100%; border-bottom-right-radius: 100%; right:0;top: -10vh;height: 120vh;`
+    } else if (props.home) {
+      return `border-top-left-radius: 100%; border-bottom-left-radius: 100%; left:0;top: -5vh;height: 110vh;`
+    } else {
+      return `border-top-left-radius: 100%; border-bottom-left-radius: 100%; left:0;top: -10vh;height: 120vh;`
+    }
   }};
   ${props => {
     const color = props.color

--- a/src/components/circular.js
+++ b/src/components/circular.js
@@ -4,12 +4,15 @@ import styled from "styled-components"
 
 const SemiCircle = styled.div`
   position: absolute;
-  width: 100%;
-  min-height: 100%;
+  width: 100vh;
+  height: 110vh;
   z-index:-1;
+  top: -5vh;
   /* prettier stop */
   ${props => {
-    return props.left ? `left:0;` : `right: 0;`
+    return props.left
+      ? `border-top-right-radius: 100%; border-bottom-right-radius: 100%;`
+      : `border-top-left-radius: 100%; border-bottom-left-radius: 100%;`
   }};
   ${props => {
     const color = props.color
@@ -20,14 +23,12 @@ const SemiCircle = styled.div`
 
 const SemiCircleContainer = styled.div`
   position: absolute;
-  width: 40%;
+  width: 30%;
   min-height: 100vh;
   top: 0px;
   overflow: hidden;
   ${props => {
-    return props.left
-      ? `border-top-right-radius: 100%; border-bottom-right-radius: 100%; left:0;`
-      : `border-top-left-radius: 100%; border-bottom-left-radius: 100%; right: 0;`
+    return props.left ? `left:0;` : `right: 0;`
   }};
 `
 // console.log(height)

--- a/src/components/circular.js
+++ b/src/components/circular.js
@@ -4,15 +4,12 @@ import styled from "styled-components"
 
 const SemiCircle = styled.div`
   position: absolute;
-  width: 30%;
-  min-height: 115vh;
-  top: -35px;
+  width: 100%;
+  min-height: 100%;
   z-index:-1;
   /* prettier stop */
   ${props => {
-    return props.left
-      ? `border-top-right-radius: 50%; border-bottom-right-radius: 50%; left:0;`
-      : `border-top-left-radius: 50%; border-bottom-left-radius: 50%; right: 0;`
+    return props.left ? `left:0;` : `right: 0;`
   }};
   ${props => {
     const color = props.color
@@ -20,5 +17,18 @@ const SemiCircle = styled.div`
   }};
 }
 `
+
+const SemiCircleContainer = styled.div`
+  position: absolute;
+  width: 40%;
+  min-height: 100vh;
+  top: 0px;
+  overflow: hidden;
+  ${props => {
+    return props.left
+      ? `border-top-right-radius: 100%; border-bottom-right-radius: 100%; left:0;`
+      : `border-top-left-radius: 100%; border-bottom-left-radius: 100%; right: 0;`
+  }};
+`
 // console.log(height)
-export default SemiCircle
+export { SemiCircle, SemiCircleContainer }

--- a/src/components/circular.js
+++ b/src/components/circular.js
@@ -11,8 +11,8 @@ const SemiCircle = styled.div`
   /* prettier stop */
   ${props => {
     return props.left
-      ? `border-top-right-radius: 100%; border-bottom-right-radius: 100%;`
-      : `border-top-left-radius: 100%; border-bottom-left-radius: 100%;`
+      ? `border-top-right-radius: 100%; border-bottom-right-radius: 100%; right:0`
+      : `border-top-left-radius: 100%; border-bottom-left-radius: 100%; left:0`
   }};
   ${props => {
     const color = props.color

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,12 +4,14 @@ import { Link } from "gatsby"
 import Layout from "../components/layout"
 import Image from "../components/image"
 import SEO from "../components/seo"
-import SemiCircle from "../components/circular"
+import { SemiCircle, SemiCircleContainer } from "../components/circular"
 import { Grid } from "@material-ui/core"
 
 const IndexPage = () => (
   <Layout>
-    <SemiCircle color="#049ea8" />
+    <SemiCircleContainer>
+      <SemiCircle color="#049ea8" />
+    </SemiCircleContainer>
     <SEO title="Home" />
     <Grid container>
       <Grid item md={6}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -10,7 +10,7 @@ import { Grid } from "@material-ui/core"
 const IndexPage = () => (
   <Layout>
     <SemiCircleContainer>
-      <SemiCircle color="#049ea8" />
+      <SemiCircle color="#049ea8" home />
     </SemiCircleContainer>
     <SEO title="Home" />
     <Grid container>


### PR DESCRIPTION
Fixes sizing issues of #9 

The circular component should scale properly on all devices now, Set it's width to be 40% of the screen.

In order to modify how the circle looks and it's positioning, modify `SemiCircleContainer`, while color of the semicircle can be modified via `SemiCircle` Component.


**Preview:**
- Right Side
![image](https://user-images.githubusercontent.com/22113778/60187541-5f477b00-984b-11e9-9be0-ff45679e70a7.png)

- Left Side
![image](https://user-images.githubusercontent.com/22113778/60187612-80a86700-984b-11e9-9907-25030da930ec.png)
